### PR TITLE
Publishing the interview field notes blog post - and fixing a footnote rendering issue

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -447,17 +447,17 @@
             let top, left;
 
             if (spaceBelow >= 120 || spaceBelow >= spaceAbove) {
-                top = anchorRect.bottom + window.scrollY + 8;
+                top = anchorRect.bottom + 8;
             } else {
                 // Position above: we don't know height yet, use negative offset trick
                 popover.style.top = '-9999px';
                 popover.style.left = '-9999px';
                 popover.style.display = 'block';
                 const ph = popover.offsetHeight;
-                top = anchorRect.top + window.scrollY - ph - 8;
+                top = anchorRect.top - ph - 8;
             }
 
-            left = anchorRect.left + window.scrollX;
+            left = anchorRect.left;
             // Don't overflow right edge
             if (left + pw > vw - 12) left = vw - pw - 12;
             // Don't overflow left edge
@@ -545,7 +545,7 @@
             document.getElementById('fn-popover-num').textContent = `FOOTNOTE ${info.displayNum}`;
             const bodyEl = document.getElementById('fn-popover-body');
             bodyEl.innerHTML = info.content || '';
-            popover.style.top  = `${window.scrollY + window.innerHeight / 2 - 80}px`;
+            popover.style.top  = `${window.innerHeight / 2 - 80}px`;
             popover.style.left = `${Math.max(12, window.innerWidth / 2 - 170)}px`;
             popover.style.display = 'block';
             popover.classList.add('visible');

--- a/_posts/2026-03-25-interview-field-insights.md
+++ b/_posts/2026-03-25-interview-field-insights.md
@@ -1,0 +1,122 @@
+---
+layout: post
+title: "Field Notes: Challenges in GenAI Evaluation Science"
+date: 2026-03-25
+published: true
+category: Research
+image: "/assets/img/blogs/field-notes-interview.svg"
+authors:
+  - name: "Robert Scholz"
+  - name: "Chad Atalla"
+  - name: "Prajna Soni"
+  - name: "Leon Staufer"
+  - name: "Agathe Balayn"
+  - name: "Vilém Zouhar"
+  - name: "Namrata Mukhija"
+  - name: "Tahsin Mayeesha"
+  - name: "Patricia Paskov"
+  - name: "Subho Majumdar"
+  - name: "the EvalEval Coalition"
+tags:
+  - "Evaluation Science"
+  - "AI Evaluation"
+  - "LLMs"
+  - "Validity"
+  - "Interpretability"
+  - "Benchmarking"
+description: "Early themes from expert interviews on the challenges of evaluating generative AI systems, spanning validity, practicality, and interpretability."
+---
+
+Our [initial post launching the Science of Evaluations workstream]({{ site.baseurl }}{% post_url 2025-07-13-eval-science-kickoff %}) outlined a research agenda to document the scientific foundations of generative AI (GenAI) evaluation through systematic reviews, sociotechnical analysis, and gap identification.
+
+Since the launch, we have conducted an extensive literature review and semi-structured interviews with experts across the field to gain insights into prevailing approaches, methodological assumptions, and persistent challenges in evaluation practices. In this post, we provide an update on where that work stands today, share early themes emerging from our analysis, and highlight where additional input would be most valuable as the workstream moves forward.
+
+We use 'evaluation' broadly to refer to the methods used to gather and interpret evidence about a GenAI system[^1] regarding its performance, capabilities, propensities, and direct impacts. These include methods such as benchmarking, targeted in-context evaluations, system monitoring, automated red‑teaming, and human uplift studies. While GenAI evaluation can span many modalities, this post focuses on text-centered systems.
+
+To date, we have conducted **15 semi-structured interviews** (approximately 30 minutes each) with practitioners across leading AI labs, academia, government-linked institutions (including AI safety institutes), and evaluation-focused startups and non-profits. Their work spans development of evaluations, creation of policy, application of evaluations to models and products, and interpretation of evaluations for design and deployment decision making. Interviewees were selected in roughly equal proportions across each type of organization based on recent publications and snowball sampling, focusing on those actively shaping evaluation practice in the large language model (LLM) ecosystem. The interviews probed into methodologies, conceptual and statistical challenges, operational constraints, and gaps in the field of AI evaluations.
+
+Here we draw on the first eight fully annotated interviews. Our findings center on three key themes: **validity**, **practicality**, and **interpretability**. The open questions and challenges within these themes can serve as a useful guide for researchers, policymakers, auditors, and engineers in the AI evaluation community, shaping future research directions and informing how decision-makers interpret and act on evaluation results. We discuss each of the themes in turn below.
+
+---
+
+## Validity
+
+Validity emerged as a central challenge in interviews about the GenAI evaluation space and is receiving increasing attention across the community.[^2] Broadly, validity refers to the extent to which a measurement meaningfully captures the construct/behavior it claims to measure.
+
+Interviewees highlighted challenges across multiple aspects of validity, namely **construct validity** (whether the concept of interest is clearly specified and theoretically grounded), **content validity** (whether test items and scoring criteria appropriately reflect the construct), and **ecological validity** (whether test items capture real-world usage[^3]).
+
+Across interviews, a clear message emerged: evaluation results can only be trusted if they are grounded in a precise specification (systematization) of the concept of interest. Terms like "bias" and "quality" are often used loosely, and this ambiguity trickles down to the measurement instruments on which evaluations depend. As a result, it is difficult to determine what evaluation results actually mean with respect to the concept of interest.
+
+As interviewees put it:
+
+> "We can have **50 different benchmarks** that all talk about measuring bias, but **none of them say exactly what bias is** \[...\] I have no way of knowing which one to trust because they haven't specified precisely what concept they were trying to capture." (P1)
+
+> "Words mean different things to different people. We have to make sure that when we say we're measuring misinformation, **we are tightly defined.** \[...\] We call that context specification." (P2)
+
+The consequences extend to the test items themselves, where misalignment between test items and the target construct can undermine an entire benchmark:
+
+> "A lot of benchmarks have stuff that is kind of nonsense, and oftentimes **not even particularly related to what the benchmark is trying to measure.** So, for example, in \[a popular benchmark professedly testing hazardous biosecurity knowledge\], there are some history questions about facts about American and Soviet bio weapons programs in the seventies" (P3)
+
+Interviewees also expressed dataset-related concerns associated with ecological validity. Prior to deployment, developers may lack access to relevant real-world usage data. Even after deployment, this data may not be accessible due to privacy considerations or may be unusable due to a low signal-to-noise ratio for rare concepts of interest. This prompts developers to turn to synthetic data, which comes with its own set of challenges:
+
+> "We use a lot of synthetic \[data.\] Basically, the pipeline is a rejection sampling pipeline where you have one model generate and another model filter \[...\] Often, what we found is that **the first thing \[language models\] generate looks almost correct**, and then if you look at it for longer \[...\] it makes you realize, this is not optimal." (P4)
+
+> "We still really struggle with **ecological validity of synthetic data.** \[...\] But, using real data is also not ideal because, if you're looking for some rare phenomenon, the signal-to-noise ratio is going to be really low in real sample data. So synthetic is important for us to get a stronger signal." (P1)
+
+Even when the concept of interest is well-defined and the dataset is carefully constructed, evaluations can quickly lose relevance as usage shifts. Users may interact with a model differently as it becomes more capable, and developers may change how models are integrated into products. Such distributional shifts can quietly violate the assumptions underlying evaluation datasets.
+
+> "**The distribution is changing very quickly**… how a consumer uses a certain product that has AI with an old AI model might be very different from how they use the same product." (P5)
+
+---
+
+## Practicality
+
+Interviewees emphasized that evaluation design is also shaped by real operational constraints (e.g., budgets, timelines, privacy), citing engineering and compute costs as key blockers, which influence how concepts of interest are prioritized.
+
+> "There are, you know, a lot of risks \[...\] we have \[an\] internal repository where we're tracking risks, and it's a lot. **We don't have evaluations for all those risks.** Especially if we're trying to make it easier for \[our\] teams, we have to build these evaluations in the central platform in a central way, and that is \[...\] quite resource-intensive to do that." (P6)
+
+> "It's a balancing step \[...\] **is performing that evaluation actually worth it** with respect to the burdens and the benefits?" (P7)
+
+Even when compute resources are not a problem, many GenAI evaluation tasks examine complex sociotechnical concepts that require substantial expertise to annotate and validate accurately. Accessing such expertise at large scales requires infrastructure and costs that developers may be unwilling to pay, favoring instead LLM-based judges.
+
+> "**We never use human judges.** … It just doesn't scale like you would have to set up a pipeline, and then the humans don't have time. It's a coordination issue." (P4)
+
+More capable systems introduce further challenges. As new models and agentic systems emerge, evaluations become harder and more costly. Agent environments increase complexity, variance, and expense:
+
+> "As the models get more capable, **it is harder and harder work to get good evals** \[...\] They are deployed as agents and environments \[…\] that have greater complexity: Firstly, the variance in their performance is much much greater. There's a lot more randomness in their interaction with the environment. And secondly, the cost goes up." (P5)
+
+---
+
+## Interpretability and Reporting
+
+Interviewees also highlighted challenges in interpreting the evidence underlying evaluative claims. As benchmarks grow larger and more complex, translating results into relevant analyses for a variety of decision makers is becoming harder and more tooling-dependent (e.g., AI agents take 100s of steps to solve a single long horizon task, intermingling tool calls with reasoning tokens, making it hard for a single person to process them without access to tooling), furthering practicality issues.
+
+As evaluation benchmarks grow in size, individual human review becomes impractical:
+
+> "Increasingly, as the benchmarks get bigger and more complicated, it's **harder to have this intuitive feel for the data.** You're more reliant on external tooling and systems to sanity check things than you were in the past." (P5)
+
+> "**Humans are just not capable of inspecting 10,000 runs** through an environment. And so we need a lot of AI assistance to understand what is going on." (P5)
+
+More broadly, interviewees noted that stronger grounding in basic statistical practice could improve rigor and the reliability of resulting claims:
+
+> "There are **massive, very common, huge statistical issues** in the way that people go about doing their evaluations, whether it's not including error bars, whether it's conflating statistical significance with effect size, whether it's just interpreting statistics sometimes." (P3)
+
+Ultimately, evaluation results are intended to inform decisions about AI models and systems in the real world. It remains a major challenge to build evaluations that stakeholders can trust at decision time:
+
+> "We know that the stakeholders who are using our evaluations to make decisions really want to be able to interpret them objectively. If they see that we conducted an evaluation and the output was a 3% failure rate, they want to know **how that translates to what we expect for real users in the real world**, does that mean that 3% of users on a day-to-day basis will experience harmful outputs?" (P1)
+
+By synthesizing these challenges and open questions alongside emerging best practices and recommendations, we aim to help address them within the Science of Evaluations and broader evaluation practice space.
+
+---
+
+## What's Next?
+
+This work is ongoing; we continue to analyze additional interviews and advance our literature review, synthesizing insights across AI and adjacent fields to learn established methodologies and identify where important gaps remain. We are also expanding our stakeholder interviews to ensure that the priorities we identify reflect the perspectives of researchers, practitioners, policymakers, and auditors across industries and geographies.
+
+As we enter the next phase of the Science of Evaluations workstream, we welcome input from those developing or applying evaluation methods for generative AI and large language models (LLMs). This includes teams at labs engaged with development and evaluation of models, alongside academics, civil society, and industry practitioners. Responses will be reported only in anonymized, aggregated form, as in the current post.
+
+If you are interested in contributing, suggesting interviewees, or sharing relevant work, we invite you to reach out at [evalevalpc@googlegroups.com](mailto:evalevalpc@googlegroups.com). We see this effort as collaborative and ecosystem-wide, and we welcome participation as we continue to build the scientific foundations for AI evaluation.
+
+[^1]: For the purposes of this post, we adopt a broad, simplified interpretation of 'evaluation.' We recognize that in rigorous practice, measurement and evaluation are not synonymous (the distinction is concisely described in [*Measurement to Meaning*](https://arxiv.org/pdf/2505.10573)).
+[^2]: Quite a few studies have recently raised the issue of validity, e.g. [*Measuring what Matters*](https://openreview.net/pdf?id=mdA5lVvNcU), [*Evaluating Generative AI Systems Is a Social Science Measurement Challenge*](https://arxiv.org/pdf/2502.00561), [*Toward an evaluation science for generative AI systems*](https://arxiv.org/pdf/2503.05336), [*Understanding and Meeting Practitioner Needs*](https://aclanthology.org/2025.findings-acl.947/), [*Stereotyping Norwegian Salmon*](https://aclanthology.org/2021.acl-long.81/).
+[^3]: The concept of [ecological validity](https://en.wikipedia.org/wiki/Ecological_validity) was originally conceived in a different context and may carry additional nuance beyond our usage here.

--- a/assets/img/blogs/field-notes-interview.svg
+++ b/assets/img/blogs/field-notes-interview.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400" width="1200" height="400">
+  <defs>
+    <clipPath id="mascotClip">
+      <rect width="197.228" height="197.228" rx="11.674"/>
+    </clipPath>
+    <filter id="shadow" x="-5%" y="-5%" width="115%" height="115%">
+      <feDropShadow dx="2" dy="3" stdDeviation="4" flood-opacity="0.1"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="400" fill="#F0F8FC"/>
+
+  <!-- Decorative dots pattern -->
+  <g opacity="0.08" fill="#2C2E36">
+    <circle cx="60" cy="50" r="4"/><circle cx="60" cy="110" r="4"/><circle cx="60" cy="170" r="4"/>
+    <circle cx="60" cy="230" r="4"/><circle cx="60" cy="290" r="4"/><circle cx="60" cy="350" r="4"/>
+    <circle cx="120" cy="50" r="4"/><circle cx="120" cy="110" r="4"/><circle cx="120" cy="170" r="4"/>
+    <circle cx="120" cy="230" r="4"/><circle cx="120" cy="290" r="4"/><circle cx="120" cy="350" r="4"/>
+    <circle cx="1080" cy="50" r="4"/><circle cx="1080" cy="110" r="4"/><circle cx="1080" cy="170" r="4"/>
+    <circle cx="1080" cy="230" r="4"/><circle cx="1080" cy="290" r="4"/><circle cx="1080" cy="350" r="4"/>
+    <circle cx="1140" cy="50" r="4"/><circle cx="1140" cy="110" r="4"/><circle cx="1140" cy="170" r="4"/>
+    <circle cx="1140" cy="230" r="4"/><circle cx="1140" cy="290" r="4"/><circle cx="1140" cy="350" r="4"/>
+  </g>
+
+  <!-- Notebook / field notes element (left side) -->
+  <g transform="translate(180, 30)">
+    <rect x="0" y="0" width="280" height="340" rx="8" fill="white" stroke="#D1E5F0" stroke-width="2"/>
+    <!-- Spiral binding dots -->
+    <circle cx="0" cy="40" r="6" fill="#D1E5F0"/><circle cx="0" cy="80" r="6" fill="#D1E5F0"/>
+    <circle cx="0" cy="120" r="6" fill="#D1E5F0"/><circle cx="0" cy="160" r="6" fill="#D1E5F0"/>
+    <circle cx="0" cy="200" r="6" fill="#D1E5F0"/><circle cx="0" cy="240" r="6" fill="#D1E5F0"/>
+    <circle cx="0" cy="280" r="6" fill="#D1E5F0"/><circle cx="0" cy="320" r="6" fill="#D1E5F0"/>
+    <!-- Ruled lines -->
+    <line x1="30" y1="50" x2="260" y2="50" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="85" x2="260" y2="85" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="120" x2="260" y2="120" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="155" x2="260" y2="155" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="190" x2="260" y2="190" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="225" x2="260" y2="225" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="260" x2="260" y2="260" stroke="#E8F0F6" stroke-width="1"/>
+    <line x1="30" y1="295" x2="260" y2="295" stroke="#E8F0F6" stroke-width="1"/>
+    <!-- Text lines -->
+    <rect x="35" y="42" width="140" height="5" rx="2" fill="#92D4F3" opacity="0.6"/>
+    <rect x="35" y="77" width="200" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="35" y="112" width="170" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="35" y="147" width="210" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="35" y="182" width="120" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="35" y="217" width="190" height="5" rx="2" fill="#5BACD1" opacity="0.4"/>
+    <rect x="35" y="252" width="160" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="35" y="287" width="185" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <!-- Annotation marks -->
+  </g>
+
+  <!-- Speech bubbles -->
+  <g filter="url(#shadow)">
+    <!-- Bubble 1 -->
+    <rect x="530" y="40" width="320" height="80" rx="16" fill="white" stroke="#92D4F3" stroke-width="2"/>
+    <rect x="555" y="65" width="180" height="5" rx="2" fill="#2C2E36" opacity="0.2"/>
+    <rect x="555" y="80" width="260" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="555" y="95" width="140" height="5" rx="2" fill="#2C2E36" opacity="0.1"/>
+
+    <!-- Bubble 2 -->
+    <rect x="570" y="160" width="350" height="80" rx="16" fill="white" stroke="#5BACD1" stroke-width="2"/>
+    <rect x="595" y="185" width="280" height="5" rx="2" fill="#2C2E36" opacity="0.2"/>
+    <rect x="595" y="200" width="220" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="595" y="215" width="160" height="5" rx="2" fill="#2C2E36" opacity="0.1"/>
+
+    <!-- Bubble 3 -->
+    <rect x="540" y="270" width="300" height="80" rx="16" fill="white" stroke="#92D4F3" stroke-width="2"/>
+    <rect x="565" y="295" width="240" height="5" rx="2" fill="#2C2E36" opacity="0.2"/>
+    <rect x="565" y="310" width="200" height="5" rx="2" fill="#2C2E36" opacity="0.15"/>
+    <rect x="565" y="325" width="170" height="5" rx="2" fill="#2C2E36" opacity="0.1"/>
+  </g>
+
+  <!-- Mascot -->
+  <g transform="translate(910, 100) scale(1.1)">
+    <g clip-path="url(#mascotClip)">
+      <rect width="197.228" height="197.228" fill="#92D4F3" rx="11.674"/>
+      <path d="M47.5696 151.128L-21.7318 190.301L57.5396 225.702L87.5678 198.79C89.21 197.318 91.472 196.825 93.669 197.015C111.858 198.585 128.675 177.47 123.652 148.772C123.22 146.306 123.87 143.711 125.721 142.025C132.894 135.49 139.969 132.208 151.787 127.732C155.941 126.158 158.378 121.827 157.5 117.472C156.579 112.907 152.33 109.78 147.71 110.372C122.925 113.548 101.975 118.918 83.8911 130.969C82.4527 131.928 80.4886 131.496 79.5975 130.015C73.8703 120.496 68.2696 114.028 59.2618 108.066C56.4268 106.19 52.8446 105.95 49.6675 107.16C42.5605 109.867 40.346 118.543 43.9797 125.224C46.7325 130.285 48.8356 135.931 50.7508 143.989C51.4204 146.807 50.0908 149.703 47.5696 151.128Z" fill="#5BACD1"/>
+      <path d="M136.912 81.7587C136.912 81.7587 97.8703 73.364 74.2249 67.9949M74.2249 67.9949C77.1703 53.8327 71.9559 46.2088 71.9559 46.2088M74.2249 67.9949C71.2795 82.157 61.7455 88.8386 61.7455 88.8386" stroke="#2C2E36" stroke-width="16.0517" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+  </g>
+
+  <!-- Bottom accent line -->
+  <rect x="0" y="392" width="1200" height="8" fill="#92D4F3"/>
+</svg>


### PR DESCRIPTION
 **New blog post: "Field Notes: Challenges in GenAI Evaluation Science"**
 
 Uploads the blog post we've been working on in the eval science workstream. The post covers validity, practicality, and interpretability themes from the first 15 interviews. I also vibe-coded a header image for it based on the existing svg files in the repo.
 
PR also includes a fix for footnote positioning bug in _layouts/post.html (the pop up appeared off-screen when you clicked on the footnotes sidebar or bubble from further down a page)